### PR TITLE
Add View Transitions API support

### DIFF
--- a/docs/examples/inline-edit.md
+++ b/docs/examples/inline-edit.md
@@ -69,6 +69,37 @@ Lastly, we'll update the edit form and the "Cancel" link so that focus is return
 
 Try using the keyboard in the following demo and notice how keyboard focus is maintained as your navigate between modes.
 
+<style>
+@keyframes fade-in {
+  from { opacity: 0; }
+}
+
+@keyframes fade-out {
+  to { opacity: 0; }
+}
+
+@keyframes slide-from-right {
+  from { transform: translateX(25%); }
+}
+
+@keyframes slide-to-left {
+  to { transform: translateX(25%); }
+}
+
+/* define animations for the old and new content */
+::view-transition-old(slide-fade) {
+  animation: 200ms ease 150ms both fade-out, 200ms ease 150ms both slide-to-left;
+}
+::view-transition-new(slide-fade) {
+  animation: 300ms ease 50ms both fade-in, 300ms ease 50ms both slide-from-right;
+}
+
+form {
+  background: #fff;
+  view-transition-name: slide-fade;
+}
+</style>
+
 
 <script type="module">
   let contact = {

--- a/docs/examples/inline-edit.md
+++ b/docs/examples/inline-edit.md
@@ -121,7 +121,7 @@ form {
   window.example('/contacts/1')
 
   function edit(contact) {
-    return `<form id="contact_1" x-init x-target method="put" action="/contacts/1" x-focus="contact_1_edit" aria-label="Contact Information">
+    return `<form id="contact_1" x-init x-target x-merge.transition method="put" action="/contacts/1" x-focus="contact_1_edit" aria-label="Contact Information">
   <div>
     <label for="first_name">First Name</label>
     <input id="first_name" name="first_name" value="${contact.first_name}" style="width:18ch">
@@ -140,7 +140,7 @@ form {
   }
 
   function show(contact) {
-    return `<div id="contact_1">
+    return `<div id="contact_1" x-merge.transition>
   <p><strong>First Name</strong>: ${contact.first_name}</p>
   <p><strong>Last Name</strong>: ${contact.last_name}</p>
   <p><strong>Email</strong>: ${contact.email}</p>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -180,6 +180,12 @@ The `morph` option uses a DOM diffing algorithm to update HTML, it's a bit more 
 
 You can change the default merge strategy for all AJAX requests using the `mergeStrategy` global [configuration option](#configuration).
 
+### View transitions & animations
+
+You can animate transitions between different DOM states using the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API). This API is still in active development and is currently only supported in Chrome browsers. Alpine AJAX provides support for View Transitions and gracefully falls back to no animations if the API is not available in a browser.
+
+To enable View Transitions on an element use the `x-merge.transition` modifier. When enabled in a supported browser, you should see content automatically animate as it is merged onto the page. You can customize any transition animation via CSS by following [Chrome's documentation for customizing transitions](https://developer.chrome.com/docs/web-platform/view-transitions/#simple-customization).
+
 ## x-focus
 
 Add `x-focus` to a form or link to control keyboard focus after an AJAX request has completed. The `x-focus` attribute accepts an element `id` that will be focused. Consider the following markup, we'll assume that clicking the "Edit" link will load a form to change the listed email address:


### PR DESCRIPTION
The View Transitions API is available behind a flag in Chrome at [chrome://flags/#view-transition](chrome://flags/#view-transition). You can use it to animate transitions between elements on the page across HTTP requests. 

The View Transitions API is still an experimental feature, but there seems to be a lot excitement around it; it degrades nicely in browsers without support, so I'm considering enabling it as the new default when elements are changed via `x-target`.

The video below demonstrates the [Inline Edit](https://alpine-ajax.js.org/examples/inline-edit/) example on the Alpine AJAX site using a slide-in/out animation. The only code added to the page was this CSS:

```css
/* Setup animations */
@keyframes fade-in {
  from { opacity: 0; }
}

@keyframes fade-out {
  to { opacity: 0; }
}

@keyframes slide-from-right {
  from { transform: translateX(25%); }
}

@keyframes slide-to-left {
  to { transform: translateX(25%); }
}

/* Define animations for the old and new content */
::view-transition-old(slide-fade) {
  animation: 200ms ease 150ms both fade-out, 200ms ease 150ms both slide-to-left;
}
::view-transition-new(slide-fade) {
  animation: 300ms ease 50ms both fade-in, 300ms ease 50ms both slide-from-right;
}

/* Make the magic happen */
form {
  background: #fff;
  view-transition-name: slide-fade;
}
```

https://github.com/imacrayon/alpine-ajax/assets/3410149/f93d2c31-310b-4446-a18d-959688ea90d2
