### PR TITLE
Add History API support

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -109,6 +109,14 @@ When this form is submitted a `POST` request is issued to `/posts`. If the serve
 
 You can change the default way that `x-target` handles redirects using the `followRedirects` global [configuration option](#configuration).
 
+### History & URL Support
+
+Use the `x-target.replace` modifier to replace the URL in the browser's navigation bar when an AJAX request is issued.
+
+Use the `x-target.push` modifier to push a new history entry onto the browser's session history stack when an AJAX request is issued.
+
+`replace` simply changes the browser’s URL without adding a new entry to the browser’s session history stack, where as `push` creates a new history entry allowing your users to navigate back to the previous URL using the browser’s "Back" button.
+
 ## x-merge
 
 By default incoming HTML from the server will `replace` a targeted element. You can add `x-merge` to a targeted element to change how it merges incoming content. For example, if you wanted to `append` new items to a list of messages, you would add `x-merge="append"` to the list:

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,11 @@ let sendConfig = new WeakMap()
 let mergeConfig = new WeakMap()
 
 function Ajax(Alpine) {
-  var originalPopstate = window.onpopstate
-  window.onpopstate = function (event) {
-    if (event.state?.__AJAX__) {
-      window.location.reload(true)
-    } else {
-      originalPopstate(event)
-    }
-  }
+  window.addEventListener('popstate', (e) => {
+    if (!e.state || !e.state.__AJAX__) return
+
+    window.location.reload(true)
+  })
 
   Alpine.directive('target', (el, { modifiers, expression }, { cleanup }) => {
     let config = {

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,20 @@ let sendConfig = new WeakMap()
 let mergeConfig = new WeakMap()
 
 function Ajax(Alpine) {
+  var originalPopstate = window.onpopstate
+  window.onpopstate = function (event) {
+    if (event.state?.__AJAX__) {
+      window.location.reload(true)
+    } else {
+      originalPopstate(event)
+    }
+  }
+
   Alpine.directive('target', (el, { modifiers, expression }, { cleanup }) => {
     let config = {
       targets: parseIds(el, expression),
-      followRedirects: followRedirects(modifiers)
+      events: true,
+      ...parseModifiers(modifiers)
     }
 
     sendConfig.set(el, config)
@@ -59,18 +69,17 @@ function Ajax(Alpine) {
         referrer: source(el),
       }
 
-      let behavior = sendConfig.get(el) || {
-        followRedirects: globalConfig.followRedirects
+      let config = sendConfig.get(el) || {
+        followRedirects: globalConfig.followRedirects,
+        history: false,
       }
-      behavior = Object.assign(behavior, options)
+      config = Object.assign(config, options)
 
-      let ids = parseIds(el, behavior.targets || behavior.target)
+      let ids = parseIds(el, config.targets || config.target)
       let targets = findTargets(ids)
-      targets = behavior.sync ? addSyncTargets(targets) : targets
+      targets = config.sync ? addSyncTargets(targets) : targets
 
-      let dispatcher = behavior.events ? dispatch : () => true
-
-      return render(request, targets, el, dispatcher, redirectHandler(behavior.followRedirects))
+      return render(request, targets, el, config)
     }
   })
 }
@@ -97,10 +106,19 @@ function parseIds(el, expression = null) {
   return ids
 }
 
-function followRedirects(modifiers = []) {
-  return globalConfig.followRedirects
+function parseModifiers(modifiers = []) {
+  let followRedirects = globalConfig.followRedirects
     ? !modifiers.includes('nofollow')
     : modifiers.includes('follow')
+
+  let history = false;
+  if (modifiers.includes('push')) history = 'push'
+  if (modifiers.includes('replace')) history = 'replace'
+
+  return {
+    followRedirects,
+    history,
+  }
 }
 
 function isLocalLink(el) {
@@ -113,15 +131,16 @@ function isForm(el) {
   return el.tagName === 'FORM'
 }
 
-function listenForNavigate(el, sendConfig) {
+function listenForNavigate(el, config) {
   let handler = async (event) => {
     event.preventDefault()
     event.stopPropagation()
-    let targets = addSyncTargets(findTargets(sendConfig.targets))
+
     let request = navigateRequest(el)
+    let targets = addSyncTargets(findTargets(config.targets))
 
     try {
-      return await render(request, targets, el, dispatch, redirectHandler(sendConfig.followRedirects))
+      return await render(request, targets, el, config)
     } catch (error) {
       if (error instanceof FailedResponseError) {
         console.warn(error.message)
@@ -147,16 +166,17 @@ function navigateRequest(link) {
   }
 }
 
-function listenForSubmit(el, sendConfig) {
+function listenForSubmit(el, config) {
   let handler = async (event) => {
     event.preventDefault()
     event.stopPropagation()
-    let targets = addSyncTargets(findTargets(sendConfig.targets))
+
     let request = formRequest(el, event.submitter)
+    let targets = addSyncTargets(findTargets(config.targets))
 
     try {
       return await withSubmitter(event.submitter, () => {
-        return render(request, targets, el, dispatch, redirectHandler(sendConfig.followRedirects))
+        return render(request, targets, el, config)
       })
     } catch (error) {
       if (error instanceof FailedResponseError) {
@@ -211,14 +231,9 @@ function mergeBodyIntoAction(body, action) {
   let params = Array.from(body.entries()).filter(([key, value]) => value !== '' || value !== null)
   if (params.length) {
     let parts = action.split('#')
-    action = parts[0]
-    if (!action.includes('?')) {
-      action += '?'
-    } else {
-      action += '&'
-    }
-    action += new URLSearchParams(params)
     let hash = parts[1]
+    parts = parts[0].split('?')
+    action = parts[0] + '?' + new URLSearchParams(params)
     if (hash) {
       action += '#' + hash
     }
@@ -227,14 +242,29 @@ function mergeBodyIntoAction(body, action) {
   return action
 }
 
-async function render(request, targets, el, dispatch, redirectHandler) {
+async function render(request, targets, el, config) {
+
+  let dispatch = () => true
+  if (config.events) {
+    dispatch = (el, name, detail) => {
+      return el.dispatchEvent(
+        new CustomEvent(name, {
+          detail,
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        })
+      )
+    }
+  }
+
   if (!dispatch(el, 'ajax:before')) return
 
   targets.forEach(target => {
     target.setAttribute('aria-busy', 'true')
   })
 
-  let response = await send(request, redirectHandler)
+  let response = await send(request, config.followRedirects)
 
   if (response.ok) {
     dispatch(el, 'ajax:success', response)
@@ -279,6 +309,10 @@ async function render(request, targets, el, dispatch, redirectHandler) {
   let focus = el.getAttribute('x-focus')
   if (focus) {
     focusOn(document.getElementById(focus))
+  }
+
+  if (config.history) {
+    updateHistory(config.history, response.url)
   }
 
   return targets
@@ -334,6 +368,15 @@ function focusOn(el) {
   }, 0)
 }
 
+function updateHistory(strategy, url) {
+  let strategies = {
+    push: () => window.history.pushState({ __AJAX__: true }, '', url),
+    replace: () => window.history.replaceState({ __AJAX__: true }, '', url),
+  }
+
+  return strategies[strategy]();
+}
+
 function findTargets(ids = []) {
   return ids.map(id => {
     let target = document.getElementById(id)
@@ -357,30 +400,6 @@ function addSyncTargets(targets) {
   })
 
   return targets
-}
-
-function dispatch(el, name, detail) {
-  return el.dispatchEvent(
-    new CustomEvent(name, {
-      detail,
-      bubbles: true,
-      composed: true,
-      cancelable: true,
-    })
-  )
-}
-
-function redirectHandler(follow) {
-  return follow
-    ? (response) => response
-    : (response) => {
-      if (response.redirected) {
-        window.location.href = response.url
-        return
-      }
-
-      return response
-    }
 }
 
 function source(el) {

--- a/tests/history.cy.js
+++ b/tests/history.cy.js
@@ -1,0 +1,35 @@
+import { test, html } from './utils'
+
+test('replaces the history state with the replace modifier',
+  html`<form x-init x-target.replace id="replace" method="get" action="/replaced"><button></button></form>`,
+  ({ intercept, get, wait, location, go }) => {
+    intercept('GET', '/replaced', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="replace">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+      location('href').should('include', '/replaced');
+    })
+  }
+)
+
+test('pushes to history state with the push modifier',
+  html`<form x-init x-target.push id="replace" method="get" action="/pushed"><button></button></form>`,
+  ({ intercept, get, wait, location, go }) => {
+    intercept('GET', '/pushed', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="replace">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+      location('href').should('include', '/pushed');
+      go('back')
+      location('href').should('include', '/tests');
+    })
+  }
+)


### PR DESCRIPTION
1. `x-target.replace` will replace the current entry on the browser's history stack.
2. `x-target.push` will push a new entry onto the browser's history stack.

Fixes #19
Fixes #33 