### PR TITLE
Allow disabling ajax per submit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,10 +170,10 @@ function navigateRequest(link) {
 
 function listenForSubmit(el, config) {
   let handler = async (event) => {
-    if (event.submitter.hasAttribute('x-ajax.disable')) {
+    if (event.submitter.hasAttribute('formnoajax')) {
       return;
     }
-    
+
     event.preventDefault()
     event.stopPropagation()
 

--- a/src/index.js
+++ b/src/index.js
@@ -170,6 +170,10 @@ function navigateRequest(link) {
 
 function listenForSubmit(el, config) {
   let handler = async (event) => {
+    if (event.submitter.hasAttribute('x-ajax.disable')) {
+      return;
+    }
+    
     event.preventDefault()
     event.stopPropagation()
 


### PR DESCRIPTION
I needed a feature to skip ajax and submit normally per submit element - in my case, Shopify's cart form submission's response contains `{redirect: false}` when using ajax (or native fetch), but still somehow redirects when submitting without ajax (e.g. maybe via some logic on cart page bootstrap).

I've added the ability to set `x-ajax.disable` on a submit element (in my case the cart form 'Checkout' submit button) to submit the form without ajax. NB `x-ajax` isn't a real directive. Could be used to set other config per submit element?