### PR TITLE
Fix merging table elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,8 @@ async function render(request, targets, el, config) {
 
   if (!response.html) return
 
-  let fragment = document.createRange().createContextualFragment(response.html)
+  let wrapper = document.createRange().createContextualFragment('<template>' + response.html + '</template>')
+  let fragment = wrapper.firstElementChild.content
   let renders = targets.map(async target => {
     let template = fragment.getElementById(target.id)
     let strategy = mergeConfig.get(target)?.strategy || globalConfig.mergeStrategy

--- a/tests/merge.cy.js
+++ b/tests/merge.cy.js
@@ -88,3 +88,17 @@ test('focus is maintained when merged content is morphed',
     })
   }
 )
+
+test('table elements can be merged',
+  html`<table><tr id="row"><td>Replace</td></tr></table><form x-init x-target="row" method="post"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<tr id="row"><td>Replaced</td></tr>'
+    }).as('response')
+    get('button').focus().click()
+    wait('@response').then(() => {
+      get('#row').should('have.text', 'Replaced')
+    })
+  }
+)


### PR DESCRIPTION
This PR fixes #47 by wrapping all the incoming HTML in a `<template>` before parsing it.

`createContextualFragment` just interprets table fragments as text nodes unless they're wrapped with a template.

```js
document.createRange().createContextualFragment('<tr><td>test</td></tr>') // DocumentFragment [#text]

document.createRange().createContextualFragment('<template><tr><td>test</td></tr></template>').firstElementChild.content // DocumentFragment [#tr]
```

I considered switching to `DOMParser.parseFromString` to parse incoming HTML, however some basic performance tests showed `createContextualFragment` was just barely faster than `parseFromString` when parsing a few different sized HTML fragments & documents. `createContextualFragment` appeared to lose it's edge as the HTML grew beyond what I would consider a "typical" amount of HTML for a webpage, so I think it's okay to stick with for now.