### PR TITLE
Improve focus management

### DIFF
--- a/tests/focus.cy.js
+++ b/tests/focus.cy.js
@@ -1,15 +1,71 @@
 import { test, html } from './utils'
 
-test('focus is set with [x-focus] string',
-  html`<form x-init x-target id="replace" method="post" x-focus="toggle_button"><button aria-pressed="false">Like</button></form>`,
+test('focus is maintained when merged content is morphed',
+  html`<form x-init x-target id="replace" method="post" x-merge="morph"><button aria-pressed="false">Like</button></form>`,
   ({ intercept, get, wait }) => {
     intercept('POST', '/tests', {
       statusCode: 200,
-      body: '<form x-target id="replace" method="post"><button id="toggle_button" aria-pressed="true">Unlike</button></form>'
+      body: '<form x-target id="replace" method="post"><button aria-pressed="true">Unlike</button></form>'
     }).as('response')
     get('button').focus().click()
     wait('@response').then(() => {
       get('button').should('have.focus')
+    })
+  }
+)
+
+test('focus is set with [autofocus]',
+  html`<form x-init x-target id="replace" method="post"><button>First</button><a href="#">Second</a></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<form x-init x-target id="replace" method="post"><button>First</button><a href="#" autofocus>Second</a></form>'
+    }).as('response')
+    get('button').focus().click()
+    wait('@response').then(() => {
+      get('a').should('have.focus')
+    })
+  }
+)
+
+test('focus is ignored with the nofocus modifier',
+  html`<form x-init x-target.nofocus id="replace" method="post"><button>First</button><a href="#">Second</a></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<form x-init x-target id="replace" method="post"><button>First</button><a href="#" autofocus>Second</a></form>'
+    }).as('response')
+    get('button').focus().click()
+    wait('@response').then(() => {
+      get('a').should('not.have.focus')
+    })
+  }
+)
+
+test('first listed target is focused when multiple [autofocus] are merged',
+  html`<a href="#" autofocus id="replace2">Second</a><a href="#" autofocus id="replace1">First</a><form x-init x-target="replace1 replace2" method="post"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<a href="#" autofocus id="replace2">Second Replaced</a><a href="#" autofocus id="replace1">First Replaced</a>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#replace1').should('have.focus')
+    })
+  }
+)
+
+test('[x-autofocus] overrides [autofocus]',
+  html`<form x-init x-target id="replace" method="post"><button>First</button><a href="#">Second</a></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<form x-init x-target id="replace" method="post"><button autofocus>First</button><a href="#" x-autofocus>Second</a></form>'
+    }).as('response')
+    get('button').focus().click()
+    wait('@response').then(() => {
+      get('a').should('have.focus')
     })
   }
 )

--- a/tests/merge.cy.js
+++ b/tests/merge.cy.js
@@ -75,20 +75,6 @@ test('content is merged after',
   }
 )
 
-test('focus is maintained when merged content is morphed',
-  html`<form x-init x-target id="replace" method="post" x-merge="morph"><button aria-pressed="false">Like</button></form>`,
-  ({ intercept, get, wait }) => {
-    intercept('POST', '/tests', {
-      statusCode: 200,
-      body: '<form x-target id="replace" method="post"><button aria-pressed="true">Unlike</button></form>'
-    }).as('response')
-    get('button').focus().click()
-    wait('@response').then(() => {
-      get('button').should('have.focus')
-    })
-  }
-)
-
 test('table elements can be merged',
   html`<table><tr id="row"><td>Replace</td></tr></table><form x-init x-target="row" method="post"><button></button></form>`,
   ({ intercept, get, wait }) => {


### PR DESCRIPTION
### The problem

I'm not totally satisfied with using `x-focus` for focus management, it falls short in some cases:

 - It sets focus after every request regardless of the response status: A UI might need to focus on one element after a successful request and a totally different element when there's an error.
 - Focusing elements via their ID doesn’t always work: When a new element is created through an AJAX request it may be impossible to assume what its ID will be.
 - It ignores `autofocus`: Alpine AJAX should respect this attribute since it's already browser-native.

It's worth noting that Alpine has a first party [Focus plugin](https://alpinejs.dev/plugins/focus), it would be nice to have better support for those utilities.

### `x-autofocus` to the rescue

This PR introduces a new `x-autofocus` attribute and deprecates `x-focus`. After an AJAX request is issued and content is merged on the page, the first element with the attribute `x-autofocus`, will be automatically focused. The same is true for the browser-standard `autofocus` attribute. The only difference between `x-autofocus` and `autofocus` is that `x-autofocus` does not trigger focus on initial page loads, only when AJAX content loads.

If multiple elements are targeted in an AJAX request each target is checked for an `x-autofocus` attribute in the order specified by `x-target`, so the first target containing an `x-autofocus` will receive focus.

Fixes #52 