### PR TITLE
Add `ajax:merge` and `ajax:merged` events

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -374,9 +374,9 @@ In this example we make a `POST` request with the `email` value to the `/validat
 </table>
 </div>
 
-## AJAX events
+## Events
 
-You can listen for AJAX events to perform additional actions during an AJAX request:
+You can listen for events to perform additional actions during the life cycle of an AJAX request:
 
 <div class="table">
 <table>
@@ -387,23 +387,31 @@ You can listen for AJAX events to perform additional actions during an AJAX requ
   <tbody>
   <tr>
     <td><code>ajax:before</code></td>
-    <td>Fired before a network request is made. If this event is canceled using <code>$event.preventDefault()</code> the request will be aborted.</td>
+    <td>Fired before an network request is made. If this event is canceled using <code>$event.preventDefault()</code> the request will be aborted.</td>
   </tr>
   <tr>
     <td><code>ajax:success</code></td>
-    <td>Fired when a network request completes. <code>detail</code> contains the server response data.</td>
+    <td>Fired when an network request completes. <code>$event.detail</code> contains the server response data.</td>
   </tr>
   <tr>
     <td><code>ajax:error</code></td>
-    <td>Fired when a request responds with a `400` or `500` status code. <code>detail</code> contains the server response data.</td>
+    <td>Fired when an network request responds with a `400` or `500` status code. <code>$event.detail</code> contains the server response data.</td>
   </tr>
   <tr>
     <td><code>ajax:after</code></td>
-    <td>Fired after every successful or unsuccessful request.</td>
+    <td>Fired after every successful or unsuccessful network request.</td>
   </tr>
   <tr>
     <td><code>ajax:missing</code></td>
-    <td>Fired if a matching target is not found in the response body. <code>detail</code> contains the server response data. You may cancel this event using <code>$event.preventDefault()</code> to override the default behavior.</td>
+    <td>Fired if a matching target is not found in the response body. <code>$event.detail</code> contains the server response data. You may cancel this event using <code>$event.preventDefault()</code> to override the default behavior.</td>
+  </tr>
+  <tr>
+    <td><code>ajax:merge</code></td>
+    <td>Fired when new content is being merged into <code>$event.target</code>. You may override a merge using <code>$event.preventDefault()</code>. <code>$event.detail</code> contains the server <code>response</code> data, the <code>content</code> to merge, and a <code>merge()</code> method to continue the merge.</td>
+  </tr>
+  <tr>
+    <td><code>ajax:merged</code></td>
+    <td>Fired after new content was merged into <code>$event.target</code>.</td>
   </tr>
   </tbody>
 </table>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -376,7 +376,7 @@ In this example we make a `POST` request with the `email` value to the `/validat
 
 ## Events
 
-You can listen for events to perform additional actions during the life cycle of an AJAX request:
+You can listen for events to perform additional actions during the lifecycle of an AJAX request:
 
 <div class="table">
 <table>

--- a/docs/reference/ajax-events.md
+++ b/docs/reference/ajax-events.md
@@ -1,6 +1,0 @@
----
-eleventyNavigation:
-  key: AJAX events
-  url: /reference/#ajax-events
-  order: 9
----

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,0 +1,6 @@
+---
+eleventyNavigation:
+  key: Events
+  url: /reference/#events
+  order: 9
+---

--- a/src/index.js
+++ b/src/index.js
@@ -366,7 +366,7 @@ async function render(request, targets, el, config) {
       throw new FailedResponseError(el)
     }
 
-    let mergeTarget = async () => {
+    let mergeContent = async () => {
       let merged = await merge(strategy, target, content)
 
       if (merged) {
@@ -389,11 +389,11 @@ async function render(request, targets, el, config) {
       return merged
     }
 
-    if (!dispatch(target, 'ajax:merge', { strategy, content, merge: mergeTarget })) {
+    if (!dispatch(target, 'ajax:merge', { strategy, content, merge: mergeContent })) {
       return
     }
 
-    return mergeTarget()
+    return mergeContent()
   })
 
   return await Promise.all(renders)

--- a/tests/merge.cy.js
+++ b/tests/merge.cy.js
@@ -104,18 +104,16 @@ test('merging can be interrupted',
   }
 )
 
-test('merging can be resumed',
-  html`<form x-init x-target id="target" method="post" @ajax:merge="$event.preventDefault();document.getElementById('change').textContent = 'Changed';$event.detail.merge();"><button></button></form><div id="change"></div>`,
+test('merged content can be changed',
+  html`<form x-init x-target id="target" method="post" @ajax:merge="$event.preventDefault();$event.detail.content.innerHTML = 'Changed';$event.detail.merge();"><button></button></form>`,
   ({ intercept, get, wait }) => {
     intercept('POST', '/tests', {
       statusCode: 200,
-      body: '<h1 id="title">Success</h1><div id="target">Replaced</div>'
+      body: '<div id="target">Test</div>'
     }).as('response')
     get('button').click()
     wait('@response').then(() => {
-      get('#title').should('not.exist')
-      get('#target').should('have.text', 'Replaced')
-      get('#change').should('have.text', 'Changed')
+      get('#target').should('have.text', 'Changed')
     })
   }
 )


### PR DESCRIPTION
This PR introduces two new events to the AJAX request lifecycle:

`ajax:merge`: Fired when new content is being merged into a target:

```js
window.addEventListener('ajax:merge', (event) => {
  // Override the merge
  event.preventDefault()

  // Do stuff with the target, response, or content
  // event.target.id
  // event.detail.response.status
  // event.detail.content.querySelector(...)
  // You can even change the content being merged
  event.detail.content.innerHTML = '<p>This is kind of crazy</p>'
   
  // Complete the merge
  event.detail.merge()
})
```

`ajax:merged`: Fired after a target has been merged:


```js
window.addEventListener('ajax:merged', (event) => {
  alert(`Target #${event.target.id} has been changed!`)
})
```


Resolves #55 