### PR TITLE
Prevent `_self` from reloading the current page

### DIFF
--- a/docs/reference/x-target.md
+++ b/docs/reference/x-target.md
@@ -50,7 +50,8 @@ Add a status code modifier to `x-target` to define different targets based on th
 * `x-target.4xx="my_form"` will merge content only when a response has a 400 class status code.
 * `x-target.error="my_form"` will merge content for both 400 and 500 class status codes.
 
-When using status code modifiers you can instruct Alpine AJAX to perform a full page load by setting the target to `_self`.
+When using status code modifiers you can instruct Alpine AJAX to perform a full page load by setting the target to `_self`. <span id="_self-special-exception">However, this has one special exception:</span> When `_self` is used in combination with a 3xx status code, it will **not** trigger a full page load on redirects back to the current page. This behavior means that your forms can still redirect back to the same page to show validation errors and eventually redirect away to a new location when all input is valid. If you want to trigger a full page reload no matter what status code you get in the response, you can set the target to `_top` instead.
+
 
 #### An important note about redirect (3xx class) status codes
 
@@ -64,10 +65,10 @@ Consider this contrived form for publishing a new blog post:
   <div id="other_error"></div>
   <div id="critical_error"></div>
   <form x-init
-        x-target.302="_self"
-        x-target.404="not_found publish_form"
         x-target.5xx="critical_error"
+        x-target.404="not_found publish_form"
         x-target.error="other_error"
+        x-target.302="_self"
         x-target="publish_form"
         id="publish_form"
         method="post"
@@ -81,10 +82,11 @@ Consider this contrived form for publishing a new blog post:
   ```
 There's a lot of status modifiers in this markup so let's break it all down; when the form is submitted:
 
-* Any 3xx class status code will load the redirected URL in the browser window. (See [important note about redirects](#an-important-note-about-redirect-3xx-class-status-codes).)
+* Any 5xx class status code will target `critical_error`.
 * A 404 status code will target `not_found` **and** `publish_form`.
 * All other 4xx class status codes will target `other_error` (thanks to `x-target.error`).
-* Any 5xx class status code will target `critical_error`.
+* Any 3xx class status code redirecting to a different page will load the redirected URL in the browser window (See [important note about redirects](#an-important-note-about-redirect-3xx-class-status-codes).)
+* Any 3xx class status code redirecting back to the current page will target `publish_form`   (See [the `_self` special exception](#_self-special-exception).)
 * All other response status codes will target `publish_form`.
 
 ### Target shorthand

--- a/tests/status.cy.js
+++ b/tests/status.cy.js
@@ -139,13 +139,67 @@ test('follows redirects by default',
   }
 )
 
-test('targeting `_self` will refresh the page',
+test('targeting `_self` will reload the page',
   html`<form x-init x-target x-target.302="_self" id="replace" method="post"><button></button></form>`,
   ({ intercept, get, wait }) => {
     intercept('POST', '/tests', (request) => {
       request.redirect('/redirect', 302)
     })
     intercept('GET', '/redirect', {
+      statusCode: 200,
+      body: '<h1 id="title">Redirected</h1><div id="replace">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('have.text', 'Redirected')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)
+
+test('targeting `_self` will not reload the page when redirected back to the same URL',
+  html`<form x-init x-target x-target.302="_self" id="replace" method="post"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', (request) => {
+      request.redirect('/tests', 302)
+    })
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Redirected</h1><div id="replace">Validation Error</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Validation Error')
+    })
+  }
+)
+
+test('targeting `_top` will reload the page',
+  html`<form x-init x-target x-target.302="_top" id="replace" method="post"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', (request) => {
+      request.redirect('/redirect', 302)
+    })
+    intercept('GET', '/redirect', {
+      statusCode: 200,
+      body: '<h1 id="title">Redirected</h1><div id="replace">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('have.text', 'Redirected')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)
+
+test('targeting `_top` will reload the page when redirected back to the same URL',
+  html`<form x-init x-target x-target.302="_top" id="replace" method="post"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', (request) => {
+      request.redirect('/tests', 302)
+    })
+    intercept('GET', '/tests', {
       statusCode: 200,
       body: '<h1 id="title">Redirected</h1><div id="replace">Replaced</div>'
     }).as('response')


### PR DESCRIPTION
This PR adds some additional support for form validation to the special `_self` target keyword and introduces the new `_top` keyword.

The discussion surrounding these changes is here: https://github.com/imacrayon/alpine-ajax/issues/79

@gregmsanderson puts it best in regards to validating a form submission:

> What we'd need is for the 302 caused by the validation error to target the form element (and so not cause a full-page reload) but the 302 caused by a successful submit to use _self and so do a full page load.

So the new behavior added to `_self` works like this:

```
<form id="my_form" x-target="my_form" x-target.3xx="_self">
```

* Any 3xx class status code redirecting to a different page will load the redirected URL in the browser window
* Any 3xx class status code redirecting back to the **current page** will target `my_form`.

For developers who want to trigger a full-page reload no matter what the status code is, we've added a new `_top` target key word that behaves just like `_self` did before this PR.

```
<form id="my_form" x-target="my_form" x-target.3xx="_top">
```

Fixes #79 