### PR TITLE
examples/dialog.md - Add missing close button to sample html

### DIFF
--- a/docs/examples/dialog.md
+++ b/docs/examples/dialog.md
@@ -18,6 +18,7 @@ We start an empty `<dialog>` and a list of links that target the `<dialog>`.
 
 <dialog x-init @dialog:open.window="$el.showModal()">
   <div id="contact"></div>
+  <form method="dialog" novalidate><button>Close</button></form>
 </dialog>
 ```
 


### PR DESCRIPTION
The modal dialog sample is missing close button, which exists in the actual demo script on this page.