### PR TITLE
Allow $ajax to recover from aborted requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imacrayon/alpine-ajax",
   "description": "An Alpine.js plugin for building server-powered frontends.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "author": "Christian Taylor",
   "homepage": "https://alpine-ajax.js.org",

--- a/src/index.js
+++ b/src/index.js
@@ -77,12 +77,20 @@ function Ajax(Alpine) {
       let method = options.method ? options.method.toUpperCase() : 'GET'
       let body = options.body
 
-      let response = await request(el, targets, action, referrer, headers, method, body)
+      try {
+        let response = await request(el, targets, action, referrer, headers, method, body)
 
-      let history = ('history' in options) ? options.history : false
-      let focus = ('focus' in options) ? options.focus : true
+        let history = ('history' in options) ? options.history : false
+        let focus = ('focus' in options) ? options.focus : true
 
-      return render(response, el, targets, history, focus)
+        return render(response, el, targets, history, focus)
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return
+        }
+
+        throw error
+      }
     }
   })
 


### PR DESCRIPTION
The `$ajax()` method should just ignore aborted requests is the same way that `<form>` and `<a>` elements do.

Fixes #90 