### PR TITLE
Add support for mapping targets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ let settings = {
   headers: {},
   mergeStrategy: 'replace',
   transitions: false,
+  mapDelimiter: ':',
 }
 
 let doMorph = (from, to) => {
@@ -334,7 +335,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
     'xxx',
   ].find(key => key in control.target)
   plan = control.target[key]
-  if (!plan.ids.includes('_self') || !response.redirected || !sameUrl(new URL(response.url), window.location)) {
+  if (!plan.ids.flat().includes('_self') || !response.redirected || !sameUrl(new URL(response.url), window.location)) {
     targets.forEach(target => target._ajax_abort())
     targets = createTargets(plan, controller)
   }
@@ -423,15 +424,16 @@ function createTargets(plan, controller) {
     return el
   }
 
-  let targets = plan.ids.map(id => {
-    let el = ['_self', '_top'].includes(id) ? document.documentElement : document.getElementById(id)
+  let targets = plan.ids.map(pair => {
+    let docId = pair[0]
+    let el = ['_self', '_top'].includes(docId) ? document.documentElement : document.getElementById(docId)
     if (!el) {
-      console.warn(`Target [#${id}] was not found in current document.`)
+      console.warn(`Target [#${docId}] was not found in current document.`)
       return
     }
 
     let target = decorate(el)
-    target._ajax_id = id
+    target._ajax_id = pair[1]
 
     return target
   }).filter(target => target)
@@ -556,12 +558,17 @@ function updateHistory(strategy, url) {
 }
 
 function parseIds(el, ids = null) {
-  let parsed = [el.getAttribute('id')]
+  let elId = el.getAttribute('id')
+  let parsed = [elId]
   if (ids) {
     parsed = Array.isArray(ids) ? ids : ids.split(' ')
   }
-  parsed = parsed.filter(id => id)
-
+  parsed = parsed.filter(id => id).map(id => {
+    let pair = id.split(settings.mapDelimiter).map(id => id || elId)
+    pair[1] = pair[1] || pair[0]
+    return pair
+  })
+  console.log(JSON.stringify(parsed))
   if (parsed.length === 0) {
     throw new IDError(el)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -568,7 +568,6 @@ function parseIds(el, ids = null) {
     pair[1] = pair[1] || pair[0]
     return pair
   })
-  console.log(JSON.stringify(parsed))
   if (parsed.length === 0) {
     throw new IDError(el)
   }

--- a/tests/map.cy.js
+++ b/tests/map.cy.js
@@ -1,0 +1,64 @@
+import { test, html } from './utils'
+
+test('can map response target to a different document target',
+  html`<div id="replace" x-merge="update"></div><form x-target="replace:target"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="replace">Error</div><div id="target">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)
+
+test('can have multiple target mappings',
+  html`<div id="replace_1" x-merge="update"></div><div id="replace_2" x-merge="update"></div><form x-target="replace_1:target_1 replace_2:target_2" method="post" action="/tests"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="target_1">Replaced #1</div><div id="target_2">Replaced #2</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace_1').should('have.text', 'Replaced #1')
+      get('#replace_2').should('have.text', 'Replaced #2')
+      get('form').should('exist')
+    })
+  }
+)
+
+test('mapping can omit current element target',
+  html`<form id="replace" x-target=":target" x-merge="update"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="replace">Error</div><div id="target">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)
+
+test('mapping can omit response element target',
+  html`<div id="replace" x-merge="update"></div><form id="target" x-target="replace:"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="replace">Error</div><div id="target">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)
+


### PR DESCRIPTION
Implements #102 

As described in the feature suggestion, this makes it possible to map elements in the current document to elements in the requested html with different element ids.

A new test file has also been added to test for expected behavior.
These are all valid targets:
- "replace:target"
- "replace1:target1 replace2:target2"
- "replace:"
- ":target"

The empty side of the mapping defaults to the current element id.

One thing to note: Since the default merge strategy is "replace" not just the children but also the target element itself will be replaced. This means that for the mapping "replace:target", once the merge has occurred there will no longer be an element in the page with an id of "replace" since it would have been replaced with the target element, and subsequent triggers of the same definition will fail since the element "replace" no longer exists.

Assumably a developer would want to use the "update" strategy instead. It might be worth considering having a separate default for when the mapped targets differ, but that also potentially makes it more confusing and complex where documentation would have sufficed.