### PR TITLE
Allow raw response text to be read from event listeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
       let text = await response.text()
       let wrapper = document.createRange().createContextualFragment('<template>' + text + '</template>')
       response.html = wrapper.firstElementChild.content
-
+      response.raw = text
       return response
     })
 


### PR DESCRIPTION
Because response.text() cannot be called twice, it's currently impossible to read the response body if the response wasn't in html which limits the functionality event listeners can provide.

This change simply stores the raw text we've read in the response object that we're providing event listeners, so that they have access to that data as well.