### PR TITLE
Support global settings for CDN loaded scripts

### DIFF
--- a/builds/cdn.js
+++ b/builds/cdn.js
@@ -1,5 +1,6 @@
 import ajax from '../src/index'
 
 document.addEventListener('alpine:initializing', () => {
+  ajax.configure(window.alpineAJAX || {})
   ajax(window.Alpine)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-let settings = Object.assign({
+let settings = {
   headers: {},
   mergeStrategy: 'replace',
   transitions: false,
   mapDelimiter: ':',
-}, window.alpineAJAX || {})
+}
 
 let doMorph = () => {
   console.error(`You can't use the "morph" merge without first installing the Alpine "morph" plugin here: https://alpinejs.dev/plugins/morph`)

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ function Ajax(Alpine) {
         started = true
       }
     },
+    configure: Ajax.configure,
     stop() {
       document.removeEventListener('submit', handleForms)
       document.removeEventListener('click', handleLinks)

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-let settings = {
+let settings = Object.assign({
   headers: {},
   mergeStrategy: 'replace',
   transitions: false,
   mapDelimiter: ':',
-}
+}, window.alpineAJAX || {})
 
 let doMorph = () => {
   console.error(`You can't use the "morph" merge without first installing the Alpine "morph" plugin here: https://alpinejs.dev/plugins/morph`)

--- a/tests/cdn-late.html
+++ b/tests/cdn-late.html
@@ -1,0 +1,17 @@
+<html>
+<script defer src="../../dist/cdn.min.js"></script>
+<script defer src="../../node_modules/alpinejs/dist/cdn.min.js"></script>
+<!-- Using a <blockquote> because it's an obscure tag -->
+<!-- which allows us to use document.querySelector()  -->
+<!-- with generic tags freely inside Cypress tests.   -->
+<blockquote id="root">
+  <!-- This is where our test subjects will be injected. -->
+</blockquote>
+<script>
+  window.addEventListener('load', function() {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    Alpine.ajax.configure(JSON.parse(urlParams.get('config')))
+  });
+</script>
+</html>

--- a/tests/cdn.cy.js
+++ b/tests/cdn.cy.js
@@ -1,0 +1,58 @@
+import { html } from './utils';
+
+function configure(config) {
+  const params = new URLSearchParams();
+
+  params.set('config', JSON.stringify(config))
+
+  return params.toString();
+}
+
+export let test = function (name, template, callback, config) {
+  it(
+    name,
+    () => {
+      cy.visit('/tests/cdn.html?' + config)
+      cy.get('#root').then(([el]) => {
+        el.innerHTML = template
+      })
+      callback(cy, config)
+    }
+  )
+}
+
+test('default merge strategy can be changed',
+  html`<form x-target id="target" method="post"><button></button></form>`,
+  ({ intercept, get, wait }, config) => {
+    intercept('POST', '/tests/cdn.html?' + config, {
+      statusCode: 200,
+      body: '<div id="target">Prepend</div><h1 id="title">Success</h1>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#target').should('have.html', 'Prepend<button></button>')
+    })
+  },
+  configure({
+    mergeStrategy: 'prepend',
+  })
+)
+
+test('default request headers can be set',
+  html`<form x-target id="target" method="post"><button></button></form>`,
+  ({ intercept, get, wait }, config) => {
+    intercept('POST', '/tests/cdn.html?' + config, {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="target">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').its('request.headers').should('have.property', 'x-alpine-nonce', 'test').then(() => {
+      get('#title').should('not.exist')
+      get('#target').should('have.html', 'Replaced')
+    })
+  },
+  configure({
+    headers: { 'X-Alpine-Nonce': 'test' }
+  })
+)

--- a/tests/cdn.cy.js
+++ b/tests/cdn.cy.js
@@ -12,11 +12,26 @@ export let test = function (name, template, callback, config) {
   it(
     name,
     () => {
-      cy.visit('/tests/cdn.html?' + config)
+      const urlWithConfig = '/tests/cdn.html?' + config
+
+      cy.visit(urlWithConfig)
       cy.get('#root').then(([el]) => {
         el.innerHTML = template
       })
-      callback(cy, config)
+      callback(cy, urlWithConfig)
+    }
+  )
+
+  it(
+    `late: ${name}`,
+    () => {
+      const urlWithConfig = '/tests/cdn-late.html?' + config
+
+      cy.visit(urlWithConfig)
+      cy.get('#root').then(([el]) => {
+        el.innerHTML = template
+      })
+      callback(cy, urlWithConfig)
     }
   )
 }
@@ -24,7 +39,7 @@ export let test = function (name, template, callback, config) {
 test('default merge strategy can be changed',
   html`<form x-target id="target" method="post"><button></button></form>`,
   ({ intercept, get, wait }, config) => {
-    intercept('POST', '/tests/cdn.html?' + config, {
+    intercept('POST', config, {
       statusCode: 200,
       body: '<div id="target">Prepend</div><h1 id="title">Success</h1>'
     }).as('response')
@@ -42,7 +57,7 @@ test('default merge strategy can be changed',
 test('default request headers can be set',
   html`<form x-target id="target" method="post"><button></button></form>`,
   ({ intercept, get, wait }, config) => {
-    intercept('POST', '/tests/cdn.html?' + config, {
+    intercept('POST', config, {
       statusCode: 200,
       body: '<h1 id="title">Success</h1><div id="target">Replaced</div>'
     }).as('response')

--- a/tests/cdn.html
+++ b/tests/cdn.html
@@ -1,0 +1,15 @@
+<html>
+<script defer src="../../dist/cdn.min.js"></script>
+<script defer src="../../node_modules/alpinejs/dist/cdn.min.js"></script>
+<!-- Using a <blockquote> because it's an obscure tag -->
+<!-- which allows us to use document.querySelector()  -->
+<!-- with generic tags freely inside Cypress tests.   -->
+<blockquote id="root">
+  <!-- This is where our test subjects will be injected. -->
+</blockquote>
+<script>
+  const urlParams = new URLSearchParams(window.location.search);
+
+  window.alpineAJAX = JSON.parse(urlParams.get('config'));
+</script>
+</html>


### PR DESCRIPTION
Example usage would be:

```html
<script defer src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.0/dist/cdn.min.js"></script>
<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>

<script>
    window.alpineAJAX = {
        // custom configuration go here
        // https://alpine-ajax.js.org/reference/#configuration
    }
</script>
```