### PR TITLE
Add `configure` method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imacrayon/alpine-ajax",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imacrayon/alpine-ajax",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,9 @@ function Ajax(Alpine) {
       window.removeEventListener('popstate', handleHistory)
       started = false
     },
+    configure (options) {
+      settings = Object.assign(settings, options)
+    },
   }
   Alpine.ajax.start()
 }


### PR DESCRIPTION
Now it is possible to configure Alpine AJAX when using it via CDN.