### PR TITLE
Add new init selector for `merge.transition`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ function Ajax(Alpine) {
   })
 
   Alpine.addInitSelector(() => `[${Alpine.prefixed('merge')}]`)
+  Alpine.addInitSelector(() => `[${Alpine.prefixed('merge\\.transition')}]`)
   Alpine.directive('merge', (el, { value, modifiers, expression }, { evaluateLater, effect }) => {
     let setMerge = (strategy) => {
       el._ajax_strategy = strategy


### PR DESCRIPTION
This change addresses an issue where view transitions were not being applied on the first AJAX request for elements using the `x-merge.transition` directive.

The directive was not being initialized on page load because the init selector was only looking for `[x-merge]` and not `[x-merge.transition]`. This meant the property was not set until after the first AJAX-triggered replacement. `_ajax_transition`

By adding a new init selector for `merge.transition`, we ensure these directives are correctly initialized when the page first loads, allowing view transitions to work as expected on the initial request.
