### PR TITLE
Remove aria-busy from root node when target is _none

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -402,6 +402,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
   let renders = PendingTargets.get(response).map(async target => {
 
     if (!target.isConnected || target._ajax_id === '_none') {
+      PendingTargets.delete(target)
       return
     }
 

--- a/tests/load.cy.js
+++ b/tests/load.cy.js
@@ -107,3 +107,19 @@ test('aria-busy is removed from targets that are not replaced',
     })
   }
 )
+
+test('aria-busy is removed from root node when target is _none',
+  html`<html><a href="/tests" x-target="_none">Link</a></html>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      delay: 1000,
+      statusCode: 200,
+      body: '',
+    }).as('response')
+    get('a').click()
+    get('html').should('have.attr', 'aria-busy')
+    wait('@response').then(() => {
+      get('html').should('not.have.attr', 'aria-busy')
+    })
+  }
+)


### PR DESCRIPTION
Hi there, I've started using Alpine Ajax since yesterday. I really like the approach.

I did notice a minor bug when using `x-target="_none"`. An `aria-busy="true"` attribute is added to the root node, but it's never removed once the target request is finished.

I've fixed the bug and added a test case for it. Let me know if you need anything else.