### PR TITLE
Prevent white flash on full page reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -408,6 +408,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
 
     if (target === document.documentElement) {
       window.location.href = response.url
+      return
     }
 
     let content = response.html.getElementById(target._ajax_id)


### PR DESCRIPTION
Hi, this PR fixes a minor issue causing a white flash (page flicker) during a full page reload (targeting `_top`). The flicker is especially noticeable on pages with dark backgrounds.