### PR TITLE
v0.13

### DIFF
--- a/docs/reference/x-target.md
+++ b/docs/reference/x-target.md
@@ -135,13 +135,9 @@ Sometimes simple target literals (i.e. comment_1) are not sufficient. In these c
 </template>
 ```
 
-### History & URL Support
+### Updating the URL
 
-Use the `x-target.replace` modifier to replace the URL in the browser's navigation bar when an AJAX request is issued.
-
-Use the `x-target.push` modifier to push a new history entry onto the browser's session history stack when an AJAX request is issued.
-
-`replace` simply changes the browser’s URL without adding a new entry to the browser’s session history stack, where as `push` creates a new history entry allowing your users to navigate back to the previous URL using the browser’s "Back" button.
+Use the `x-target.url` modifier to replace the URL in the browser's navigation bar when an AJAX request is issued.
 
 ### Disable AJAX per submit button
 

--- a/tests/events.cy.js
+++ b/tests/events.cy.js
@@ -35,7 +35,7 @@ test('[ajax:before] can cancel AJAX requests',
 )
 
 test('[ajax:send] can modify a request',
-  html`<form x-target id="replace" method="post" @ajax:send="$event.detail.action = '/changed'"><button></button></form>`,
+  html`<form x-target id="replace" method="post" @ajax:send="$event.detail.request.action = '/changed'"><button></button></form>`,
   ({ intercept, get, wait }) => {
     intercept('POST', '/changed', {
       statusCode: 200,

--- a/tests/exceptions.cy.js
+++ b/tests/exceptions.cy.js
@@ -1,17 +1,5 @@
 import { test, html } from './utils'
 
-test('Element throws an exception when a target is missing',
-  html`<form x-target="not_found" method="post" action="/tests"><button></button></form>`,
-  ({ intercept, get }) => {
-    intercept('POST', '/tests', {
-      statusCode: 200,
-      body: '<h1 id="title">Success</h1><div id="replace">Replaced</div>'
-    }).as('response')
-    get('button').click()
-  },
-  (err) => err.name === 'TargetError'
-)
-
 test('Target throws an exception when it is missing an ID',
   html`<form x-target method="post" action="/tests"><button></button></form>`,
   ({ intercept, get }) => {

--- a/tests/history.cy.js
+++ b/tests/history.cy.js
@@ -15,21 +15,3 @@ test('replaces the history state with the replace modifier',
     })
   }
 )
-
-test('pushes to history state with the push modifier',
-  html`<form x-target.push id="replace" method="get" action="/pushed"><button></button></form>`,
-  ({ intercept, get, wait, location, go }) => {
-    intercept('GET', '/pushed', {
-      statusCode: 200,
-      body: '<h1 id="title">Success</h1><div id="replace">Replaced</div>'
-    }).as('response')
-    get('button').click()
-    wait('@response').then(() => {
-      get('#title').should('not.exist')
-      get('#replace').should('have.text', 'Replaced')
-      location('href').should('include', '/pushed');
-      go('back')
-      location('href').should('include', '/tests');
-    })
-  }
-)

--- a/tests/load.cy.js
+++ b/tests/load.cy.js
@@ -77,7 +77,7 @@ test('content is lazily loaded with a custom event trigger',
   }
 )
 
-test('aria-busy is added to busy targets',
+test('[aria-busy] is added to busy targets',
   html`<a href="/tests" x-target id="replace">Link</a>`,
   ({ intercept, get, wait }) => {
     intercept('GET', '/tests', {
@@ -92,7 +92,7 @@ test('aria-busy is added to busy targets',
   }
 )
 
-test('aria-busy is removed from targets that are not replaced',
+test('[aria-busy] is removed from targets that are not replaced',
   html`<div id="append" x-merge="append"><a href="/tests" x-target="append">Link</a><div>`,
   ({ intercept, get, wait }) => {
     intercept('GET', '/tests', {
@@ -108,18 +108,21 @@ test('aria-busy is removed from targets that are not replaced',
   }
 )
 
-test('aria-busy is removed from root node when target is _none',
-  html`<html><a href="/tests" x-target="_none">Link</a></html>`,
-  ({ intercept, get, wait }) => {
-    intercept('GET', '/tests', {
-      delay: 1000,
-      statusCode: 200,
-      body: '',
-    }).as('response')
-    get('a').click()
-    get('html').should('have.attr', 'aria-busy')
-    wait('@response').then(() => {
-      get('html').should('not.have.attr', 'aria-busy')
-    })
-  }
-)
+// This Cypress bug is breaking this test
+// https://github.com/cypress-io/cypress/issues/26206
+//
+// test('[aria-busy] is removed from root node when target is _none',
+//   html`<form x-target="_none"><button></button></form>`,
+//   ({ intercept, get, wait }) => {
+//     intercept('GET', '/tests', {
+//       delay: 1000,
+//       statusCode: 200,
+//       body: '',
+//     }).as('response')
+//     get('button').click()
+//     get('form').should('have.attr', 'aria-busy')
+//     wait('@response').then(() => {
+//       get('form').should('not.have.attr', 'aria-busy')
+//     })
+//   }
+// )

--- a/tests/map.cy.js
+++ b/tests/map.cy.js
@@ -62,3 +62,17 @@ test('mapping can omit response element target',
   }
 )
 
+test('target delimiter is optional',
+  html`<div id="replace" x-merge="update"></div><form id="error" x-target="replace"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="error">Error</div><div id="replace">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#replace').should('have.text', 'Replaced')
+    })
+  }
+)

--- a/tests/merge.cy.js
+++ b/tests/merge.cy.js
@@ -105,7 +105,7 @@ test('merging can be interrupted',
 )
 
 test('merged content can be changed',
-  html`<form x-target id="target" method="post" @ajax:merge="$event.preventDefault();$event.detail.content.innerHTML = 'Changed';$event.detail.merge();"><button></button></form>`,
+  html`<form x-target id="target" method="post" @ajax:merge="$event.detail.content.innerHTML = 'Changed';"><button></button></form>`,
   ({ intercept, get, wait }) => {
     intercept('POST', '/tests', {
       statusCode: 200,
@@ -114,6 +114,21 @@ test('merged content can be changed',
     get('button').click()
     wait('@response').then(() => {
       get('#target').should('have.text', 'Changed')
+    })
+  }
+)
+
+test('merged strategy can be changed',
+  html`<form x-target id="target" method="post" x-merge="after" x-on:ajax:merge="$event.detail.strategy = 'update'"><button></button></form>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<h1 id="title">Success</h1><div id="target">Replaced</div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#title').should('not.exist')
+      get('#target').should('have.html', 'Replaced')
     })
   }
 )

--- a/tests/status.cy.js
+++ b/tests/status.cy.js
@@ -209,42 +209,6 @@ test('follows redirects by default',
   }
 )
 
-test('targeting `_self` will reload the page',
-  html`<form x-target x-target.302="_self" id="replace" method="post"><button></button></form>`,
-  ({ intercept, get, wait }) => {
-    intercept('POST', '/tests', (request) => {
-      request.redirect('/redirect', 302)
-    })
-    intercept('GET', '/redirect', {
-      statusCode: 200,
-      body: '<h1 id="title">Redirected</h1><div id="replace">Replaced</div>'
-    }).as('response')
-    get('button').click()
-    wait('@response').then(() => {
-      get('#title').should('have.text', 'Redirected')
-      get('#replace').should('have.text', 'Replaced')
-    })
-  }
-)
-
-test('targeting `_self` will not reload the page when redirected back to the same URL',
-  html`<form x-target x-target.302="_self" id="replace" method="post"><button></button></form>`,
-  ({ intercept, get, wait }) => {
-    intercept('POST', '/tests', (request) => {
-      request.redirect('/tests', 302)
-    })
-    intercept('GET', '/tests', {
-      statusCode: 200,
-      body: '<h1 id="title">Redirected</h1><div id="replace">Validation Error</div>'
-    }).as('response')
-    get('button').click()
-    wait('@response').then(() => {
-      get('#title').should('not.exist')
-      get('#replace').should('have.text', 'Validation Error')
-    })
-  }
-)
-
 test('targeting `_top` will reload the page',
   html`<form x-target x-target.302="_top" id="replace" method="post"><button></button></form>`,
   ({ intercept, get, wait }) => {


### PR DESCRIPTION
Streamlining code, making things more extensible

- [x] Clean up merge overriding
- [x] Remove history.push
- [x] Add `Alpine.ajax.merge()`
- [x] Normalize `detail` in `ajax` events
- [x] Drop support for `target.push`
- [ ] Support CSS animations
- [ ] Support ViewTransitions for multiple targets
- [ ] Enable ViewTransitions by default? (needs more research)
- [ ] Add `x-target.once`? (needs more research)
- [ ] Add SSE support

Breaking Changes
* `ajax:sent `details` changed
* Dropped support for `target.push`