### PR TITLE
Fix ajax:after event not firing after trigger removal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
   }
 
   if (!request.enctype) { delete request.enctype } // Let browser set the correct multipart boundary
-  
+
   dispatch(control.el, 'ajax:send', request)
 
   let pending
@@ -463,7 +463,12 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
 
   let render = await Promise.all(renders)
 
-  dispatch(control.el, 'ajax:after', { response, render })
+  // check if the element is still in the DOM
+  if (control.el && control.el.isConnected) {
+    dispatch(control.el, 'ajax:after', { response, render })
+  } else {
+    dispatch(window, 'ajax:after', { response, render })
+  }
 
   return render
 }

--- a/tests/events.cy.js
+++ b/tests/events.cy.js
@@ -82,10 +82,10 @@ test('[ajax:redirect] can handle redirects',
 )
 
 test('[ajax:after] event is fired when element stays present',
-  html`<div x-init id="content-container" @ajax:after="$el.dataset.didChange='yes'" data-did-change="no">
+  html`<div x-init id="content-container" @ajax:after.window="$el.dataset.didChange='yes'" data-did-change="no">
     <p id="before" x-sync>CHANGE ME</p>
     <form
-      x-target="before replace"
+      x-target
       x-merge="update"
       id="replace"
       method="post"
@@ -97,7 +97,7 @@ test('[ajax:after] event is fired when element stays present',
   ({ intercept, get, wait }) => {
     intercept('POST', '/tests', {
       statusCode: 200,
-      body: '<p id="before">Changed</p><span id="replace">Success</span>'
+      body: '<div id="content-container"><p id="before">Changed</p><h1 id="replace">Success</h1></div>'
     }).as('response')
     get('button').click()
     wait('@response').then(() => {
@@ -110,10 +110,10 @@ test('[ajax:after] event is fired when element stays present',
 )
 
 test('[ajax:after] event is fired when element is removed',
-  html`<div x-init id="content-container" x-merge="update" x-sync @ajax:after="$el.dataset.didChange='yes'" data-did-change="no">
-    <p id="before">CHANGE ME</p>
+  html`<div x-init id="content-container" x-merge="update" x-sync @ajax:after.window="$el.dataset.didChange='yes'" data-did-change="no">
+    <p id="before" x-sync>CHANGE ME</p>
     <form
-      x-target="before"
+      x-target
       x-merge="update"
       id="replace"
       method="post"

--- a/tests/events.cy.js
+++ b/tests/events.cy.js
@@ -80,3 +80,59 @@ test('[ajax:redirect] can handle redirects',
   })
   `
 )
+
+test('[ajax:after] event is fired when element stays present',
+  html`<div x-init id="content-container" @ajax:after="$el.dataset.didChange='yes'" data-did-change="no">
+    <p id="before" x-sync>CHANGE ME</p>
+    <form
+      x-target="before replace"
+      x-merge="update"
+      id="replace"
+      method="post"
+      action="/tests"
+    >
+      <button></button>
+    </form>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<p id="before">Changed</p><span id="replace">Success</span>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#replace').should('have.text', 'Success')
+      get('#before').should('have.text', 'Changed')
+      get('#content-container').should('have.attr', 'data-did-change')
+      get('#content-container').should('have.attr', 'data-did-change', 'yes')
+    })
+  }
+)
+
+test('[ajax:after] event is fired when element is removed',
+  html`<div x-init id="content-container" x-merge="update" x-sync @ajax:after="$el.dataset.didChange='yes'" data-did-change="no">
+    <p id="before">CHANGE ME</p>
+    <form
+      x-target="before"
+      x-merge="update"
+      id="replace"
+      method="post"
+      action="/tests"
+    >
+      <button></button>
+    </form>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      body: '<div id="content-container"><p id="before">Changed</p><h1 id="replace">Success</h1></div>'
+    }).as('response')
+    get('button').click()
+    wait('@response').then(() => {
+      get('#replace').should('have.text', 'Success')
+      get('#before').should('have.text', 'Changed')
+      get('#content-container').should('have.attr', 'data-did-change')
+      get('#content-container').should('have.attr', 'data-did-change', 'yes')
+    })
+  }
+)


### PR DESCRIPTION
> More info regarding the bug in issue #157 

This PR fires the ajax:after event on the `window` instead of `control.el` in cases where `control.el.isConnected` returns false. This ensures that the ajax:after event gets fired even when the element triggering the ajax request may be removed from the DOM.

One consideration here is whether the fallback dispatch should be done on the `window` or the `document`. Initially I chose `window` purely out of habit, but it sounds like `document` is more appropriate when the event is related to DOM changes.