### PR TITLE
Add target as object for json responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imacrayon/alpine-ajax",
-  "version": "0.10.0",
+  "version": "0.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imacrayon/alpine-ajax",
-      "version": "0.10.0",
+      "version": "0.12.7",
       "license": "MIT",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,18 @@ function Ajax(Alpine) {
   Alpine.directive('target', (el, { value, modifiers, expression }, { evaluateLater, effect }) => {
     let setTarget = (ids) => {
       el._ajax_target = el._ajax_target || {}
-      let plan = {
-        ids: parseIds(el, ids),
-        sync: true,
-        focus: !modifiers.includes('nofocus'),
-        history: modifiers.includes('push') ? 'push' : (modifiers.includes('replace') ? 'replace' : false),
-      }
+      let isObject = ids !== null && typeof ids === 'object' && !Array.isArray(ids)
+      let plan = isObject
+        ? {
+            object: ids,
+            history: modifiers.includes('push') ? 'push' : (modifiers.includes('replace') ? 'replace' : false),
+          }
+        : {
+            ids: parseIds(el, ids),
+            sync: true,
+            focus: !modifiers.includes('nofocus'),
+            history: modifiers.includes('push') ? 'push' : (modifiers.includes('replace') ? 'replace' : false),
+          }
 
       let statues = modifiers.filter((modifier) => ['back', 'away', 'error'].includes(modifier) || parseInt(modifier))
       statues = statues.length ? statues : ['xxx']
@@ -73,16 +79,22 @@ function Ajax(Alpine) {
 
   Alpine.magic('ajax', (el) => {
     return async (action, options = {}) => {
-      let control = {
-        el,
-        target: {
-          'xxx': {
-            ids: parseIds(el, options.targets || options.target),
+      let target = options.targets || options.target
+      let isObject = target !== null && typeof target === 'object' && !Array.isArray(target)
+      let plan = isObject
+        ? {
+            object: target,
+            history: ('history' in options) ? options.history : false,
+          }
+        : {
+            ids: parseIds(el, target),
             sync: Boolean(options.sync),
             history: ('history' in options) ? options.history : false,
             focus: ('focus' in options) ? options.focus : true,
-          },
-        },
+          }
+      let control = {
+        el,
+        target: { 'xxx': plan },
         headers: options.headers || {}
       }
       let method = options.method ? options.method.toUpperCase() : 'GET'
@@ -305,8 +317,11 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
   }
 
   let plan = control.target.xxx
+  let objectTarget = plan.object || null
   let response = { ok: false, redirected: false, url: '', status: '', html: '', raw: '' }
-  PendingTargets.plan(plan, response)
+  if (!objectTarget) {
+    PendingTargets.plan(plan, response)
+  }
   let referrer = new URL(control.el.closest('[data-source]')?.dataset.source || '', document.baseURI)
   action = new URL(action || referrer, document.baseURI)
   if (body) {
@@ -329,7 +344,7 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
     referrer: referrer.toString(),
     headers: Object.assign({
       'X-Alpine-Request': true,
-      'X-Alpine-Target': PendingTargets.get(response).map(target => target._ajax_id).join(' '),
+      'X-Alpine-Target': objectTarget ? '' : PendingTargets.get(response).map(target => target._ajax_id).join(' '),
     }, settings.headers, control.headers),
   }
 
@@ -375,6 +390,24 @@ async function send(control, action = '', method = 'GET', body = null, enctype =
 
   dispatch(control.el, 'ajax:sent', response)
   RequestCache.delete(request.action)
+
+  if (objectTarget) {
+    if (response.ok) {
+      try {
+        Object.assign(objectTarget, JSON.parse(response.raw))
+      } catch (e) {
+        console.warn('alpine-ajax: Could not parse JSON response for object target', e)
+      }
+    }
+
+    if (control.el && control.el.isConnected) {
+      dispatch(control.el, 'ajax:after', { response, render: null })
+    } else {
+      dispatch(window, 'ajax:after', { response, render: null })
+    }
+
+    return
+  }
 
   if (!response.html) {
     PendingTargets.purge(response)

--- a/tests/ajax.cy.js
+++ b/tests/ajax.cy.js
@@ -115,3 +115,79 @@ test('can transform object to FormData with $ajax method',
       expect(interception.request.body).to.include('nested='+encodeURIComponent(JSON.stringify({ a: 'b' }))) // nested={"a":"b"}
     })
 })
+
+test('$ajax assigns JSON response to object target',
+  html`<div x-data="{ user: { name: '' } }" x-init>
+    <button type="button" id="btn" @click="$ajax('/tests', { target: user })"></button>
+    <span id="result" x-text="user.name"></span>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice' })
+    }).as('response')
+    get('#btn').click()
+    wait('@response').then(() => {
+      get('#result').should('have.text', 'Alice')
+    })
+  }
+)
+
+test('$ajax does not modify DOM when target is an object',
+  html`<div x-data="{ data: {} }" x-init>
+    <button type="button" id="btn" @click="$ajax('/tests', { target: data })"></button>
+    <div id="replace">Original</div>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('GET', '/tests', {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: 42 })
+    }).as('response')
+    get('#btn').click()
+    wait('@response').then(() => {
+      get('#replace').should('have.text', 'Original')
+    })
+  }
+)
+
+test('[x-target:dynamic] assigns JSON response to object target',
+  html`<div x-data="{ result: { name: '' } }" x-init>
+    <form x-target:dynamic="result" method="post" action="/tests">
+      <button id="btn"></button>
+    </form>
+    <span id="result" x-text="result.name"></span>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Bob' })
+    }).as('response')
+    get('#btn').click()
+    wait('@response').then(() => {
+      get('#result').should('have.text', 'Bob')
+    })
+  }
+)
+
+test('[x-target:dynamic] does not modify DOM when target is an object',
+  html`<div x-data="{ data: {} }" x-init>
+    <form x-target:dynamic="data" method="post" action="/tests">
+      <button id="btn"></button>
+    </form>
+    <div id="replace">Original</div>
+  </div>`,
+  ({ intercept, get, wait }) => {
+    intercept('POST', '/tests', {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: 42 })
+    }).as('response')
+    get('#btn').click()
+    wait('@response').then(() => {
+      get('#replace').should('have.text', 'Original')
+    })
+  }
+)


### PR DESCRIPTION
Suggestion to consider the target as an object.
When the AJAX response is JSON and the target is an object, the response will be associated with the target's variable, maintaining reactivity.